### PR TITLE
Protect the database ORM class instances from unknown attribute access 

### DIFF
--- a/bbndb/qgl.py
+++ b/bbndb/qgl.py
@@ -28,7 +28,7 @@ import datetime
 
 from sqlalchemy import Column, DateTime, String, Boolean, Float, Integer, LargeBinary, ForeignKey, func, PickleType
 from sqlalchemy.ext.mutable import Mutable
-from sqlalchemy.orm import relationship, backref, validates
+from sqlalchemy.orm import relationship, backref, validates, reconstructor
 from sqlalchemy.ext.declarative import declared_attr
 
 from .session import Base
@@ -69,6 +69,17 @@ class DatabaseItem(object):
         return str(self)
     def __str__(self):
         return f"{self.__class__.__name__}('{self.label}')"
+    def __setattr__(self, name, value):
+        if hasattr(self, "_locked") and self._locked:
+            if name not in ['_sa_instance_state'] and not hasattr(self, name):
+                raise Exception(f"{type(self)} does not have attribute {name}")
+        super().__setattr__(name, value)        
+    def __init__(self, *args, **kwargs):
+        self._locked = True
+        super().__init__(*args, **kwargs)
+    @reconstructor
+    def init_on_load(self):
+        self._locked = True
 
 class ChannelDatabase(Base):
     __tablename__ = "channeldatabase"
@@ -312,6 +323,17 @@ class Channel(Base):
         'polymorphic_identity':'channel',
         'polymorphic_on':type
     }
+    def __setattr__(self, name, value):
+        if hasattr(self, "_locked") and self._locked:
+            if name not in ['_sa_instance_state'] and not hasattr(self, name):
+                raise Exception(f"{type(self)} does not have attribute {name}")
+        super().__setattr__(name, value)        
+    def __init__(self, *args, **kwargs):
+        self._locked = True
+        super().__init__(*args, **kwargs)
+    @reconstructor
+    def init_on_load(self):
+        self._locked = True
 
 class ChannelMixin(object):
     @declared_attr


### PR DESCRIPTION
As with auspex instrument drivers, prevent people from assigned unknown attributes by accident, e.g.
```python
q1.fraquancy = 5.0e9 # Should raise an error! 
```
Sometimes we really do want to add new attributes — QubitExperiments make use of this functionality. In that case we can use the `_locked` attribute to give ourselves this latitude.
```python
instrument._locked = False
instrument.instr = instr
# Other changes here
instrument._locked = True
```
