### PR TITLE
Prevent user from setting `autodyne_frequency` property in a `Measurement`

### DIFF
--- a/bbndb/qgl.py
+++ b/bbndb/qgl.py
@@ -600,6 +600,16 @@ class Measurement(LogicalChannel, ChannelMixin):
     receiver_chan_id = Column(Integer, ForeignKey("receiverchannel.id"))
     processor_chan        = relationship("DigitalInput", uselist=False, backref='input_chan', foreign_keys="DigitalInput.meas_chan_id")
 
+    @property
+    def autodyne_frequency(self):
+        raise ValueError("`autodyne_frequency` is not a valid property of a Measurement. Did you mean `autodyne_freq?'")
+        return None 
+
+    @autodyne_frequency.setter
+    def autodyne_frequency(self, value):
+        raise ValueError("`autodyne_frequency` is not a valid property of a Measurement. Did you mean `autodyne_freq?'")
+        return None 
+
     # attenuator_chan = relationship("AttenuatorChannel", uselist=False, backref="measuring_chan", foreign_keys="[AttenuatorChannel.measuring_chan_id]")
     @validates('frequency')
     def validate_frequency(self, key, value):


### PR DESCRIPTION
Pros:
- Throw exception when you accidentally set `autodyne_frequency` instead of `autodyne_freq` which seems to be a common EBKAC mistake...

Cons:
- Probably a cleaner way of doing this by locking the class dict for database objects? That may be too drastic, though?
- Now autodyne_frequency *also* autocompletes in Jupyter

@grahamrow  @matthewware  thoughts? 