### PR TITLE
Feature/auto tag db versions

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -11,7 +11,8 @@ config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-fileConfig(config.config_file_name)
+if False:
+    fileConfig(config.config_file_name)
 
 # add your model's MetaData object here
 # for 'autogenerate' support
@@ -29,7 +30,7 @@ def get_url():
     if url:
         url = "sqlite:///" + url
     else:
-        print("Assuming default database location from alembic.ini")
+        # print("Assuming default database location from alembic.ini")
         url = config.get_main_option("sqlalchemy.url")
     # assert url, "Database URL must be specified on command line with -x url=<DB_URL>"
     return url

--- a/alembic/fill_db.py
+++ b/alembic/fill_db.py
@@ -2,7 +2,7 @@ from QGL import *
 from auspex.qubit import *
 import bbndb
 
-cl = ChannelLibrary(db_resource_name="BBN.sqlite")
+cl = ChannelLibrary("BBN")
 pl = PipelineManager()
 
 # Create five qubits and supporting hardware

--- a/bbndb/session.py
+++ b/bbndb/session.py
@@ -3,7 +3,12 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.pool import StaticPool
 from sqlalchemy import create_engine
 
+import alembic as al
+from alembic.config import Config as AlembicConfig
+from alembic.script import ScriptDirectory
+
 from contextlib import contextmanager
+import os
 
 # configure Session to be used by all importers
 Session = sessionmaker()
@@ -22,11 +27,42 @@ Base = declarative_base()
 def initialize_db(provider):
     global engine, Session, Base
     if not engine:
-        print("Creating engine...")
+        # print("Creating engine...")
         engine = create_engine(provider, connect_args={'check_same_thread':False},
                                      poolclass=StaticPool, echo=False)
+
         Base.metadata.create_all(engine)
         Session.configure(bind=engine)
+
+        acfg = AlembicConfig(os.path.join(os.path.dirname(__file__), "../alembic.ini"))
+        acfg.set_main_option("sqlalchemy.url", provider)
+
+        if ":memory:" not in provider:
+
+            script = ScriptDirectory.from_config(acfg)
+            heads  = script.get_revisions("heads")
+            if len(heads) > 1:
+                logger.warning("More than one database version possibility found... this is weird...")
+            bbndb_rev = heads[0].revision
+
+            # Horrible monkey-patch to get the current revision:
+            rev = None
+            def print_stdout(text, *arg):
+                nonlocal rev
+                rev = text.split()[0]
+            acfg.print_stdout = print_stdout
+
+            # Get the current revision
+            al.command.current(acfg)
+            # Stamp it with current revision if it's None
+            if rev is None:
+                al.command.stamp(acfg, bbndb_rev)
+            # Check to see if we have a version mismatch
+            # In the future, we might perform the upgrade for you.
+            elif bbndb_rev != rev:
+                print(f"Revision of the requested database {provider}: {rev} does not match the current bbndb revision: {bbndb_rev}\
+                    Please migrate the database to the current version or recreate the database. The former can be done using\
+                    the alembic command line tools. See alembic/README.md in the bbndb directory for details.")
 
 def get_cl_session():
     global Session, cl_session


### PR DESCRIPTION
@gribeill @matthewware As discussed, this now tags the database file with the current alembic head when creating a new database. Otherwise it compares the database tag to the current head, and complains vigorously if they do not match. This of course presumes that someone has actually bothered to update the alembic version if making breaking changes to the schema. Maybe a git hook it needed after all.